### PR TITLE
Interactive demo lab cards, robust API parsing, and file-backed early-access seats (plus repo check)

### DIFF
--- a/REPO_CHECK_2026-04-17.md
+++ b/REPO_CHECK_2026-04-17.md
@@ -1,0 +1,32 @@
+# Repo check rapido (2026-04-17)
+
+## Contesto
+Verifica iniziale della repo `winlab` con focus su installazione dipendenze e script base.
+
+## Comandi eseguiti
+1. `npm test`
+2. `npm ci`
+3. `npm ci --legacy-peer-deps`
+4. `npm test` (secondo tentativo)
+5. `npx prisma generate`
+6. `npm run build`
+
+## Risultati principali
+- `npm ci` fallisce per conflitto peer dependency tra `vite@8.x` e `vite-plugin-pwa@1.2.0` (supporta fino a `vite@7.x`).
+- Anche forzando con `npm ci --legacy-peer-deps`, l'ambiente resta incoerente: script base non trovano binari/artefatti attesi (`vite` non disponibile).
+- `npm test` fallisce perché `@prisma/client` non risolve `index.js` nel setup attuale.
+- `npx prisma generate` fallisce con `403 Forbidden` verso npm registry (limite ambiente/rete o policy).
+
+## Valutazione
+Stato repo **non pronto** per una verifica end-to-end in questo ambiente senza:
+1. allineamento versioni Vite/PWA,
+2. installazione dipendenze completa,
+3. generazione client Prisma con accesso registry.
+
+## Fix consigliati
+1. Allineare stack frontend:
+   - o downgrade `vite` a `^7.x`,
+   - o aggiornare/sostituire `vite-plugin-pwa` con versione compatibile `vite@8`.
+2. Rigenerare lockfile dopo l'allineamento (`rm -rf node_modules package-lock.json && npm install`).
+3. Eseguire `npx prisma generate` in ambiente con accesso npm e verificare che `node_modules/@prisma/client/index.js` esista.
+4. Rilanciare check minimi: `npm run build`, `npm test`, `npm run test:unit`.

--- a/coming-soon/index.html
+++ b/coming-soon/index.html
@@ -742,7 +742,7 @@ section{padding:80px 24px}
       <div class="labs-grid">
 
         <!-- Lab 01 -->
-        <div class="lab-card">
+        <div class="lab-card" data-scenario="linux_boot" role="button" tabindex="0" aria-label="Open demo lab: Filesystem Navigation">
           <div class="lab-card-header">
             <div><div class="lab-num">LAB 01</div><div class="lab-card-title">Filesystem Navigation</div></div>
             <div class="lab-card-meta"><span class="lab-pill pill-green">Free</span><span class="lab-pill pill-dim">~30 min</span></div>
@@ -762,7 +762,7 @@ section{padding:80px 24px}
         </div>
 
         <!-- Lab 02 -->
-        <div class="lab-card">
+        <div class="lab-card" data-scenario="apache_fix" role="button" tabindex="0" aria-label="Open demo lab: File Operations">
           <div class="lab-card-header">
             <div><div class="lab-num">LAB 02</div><div class="lab-card-title">File Operations</div></div>
             <div class="lab-card-meta"><span class="lab-pill pill-green">Free</span><span class="lab-pill pill-dim">~25 min</span></div>
@@ -781,7 +781,7 @@ section{padding:80px 24px}
         </div>
 
         <!-- Lab 03 -->
-        <div class="lab-card">
+        <div class="lab-card" data-scenario="ssh_brute" role="button" tabindex="0" aria-label="Open demo lab: Permissions and Users">
           <div class="lab-card-header">
             <div><div class="lab-num">LAB 03</div><div class="lab-card-title">Permissions &amp; Users</div></div>
             <div class="lab-card-meta"><span class="lab-pill pill-green">Free</span><span class="lab-pill pill-dim">~35 min</span></div>
@@ -799,7 +799,7 @@ section{padding:80px 24px}
         </div>
 
         <!-- Lab 04 -->
-        <div class="lab-card">
+        <div class="lab-card" data-scenario="service_fail" role="button" tabindex="0" aria-label="Open demo lab: Processes and Services">
           <div class="lab-card-header">
             <div><div class="lab-num">LAB 04</div><div class="lab-card-title">Processes &amp; Services</div></div>
             <div class="lab-card-meta"><span class="lab-pill pill-green">Free</span><span class="lab-pill pill-dim">~30 min</span></div>
@@ -818,7 +818,7 @@ section{padding:80px 24px}
         </div>
 
         <!-- Lab 05 -->
-        <div class="lab-card">
+        <div class="lab-card" data-scenario="network_outage" role="button" tabindex="0" aria-label="Open demo lab: Networking Basics">
           <div class="lab-card-header">
             <div><div class="lab-num">LAB 05</div><div class="lab-card-title">Networking Basics</div></div>
             <div class="lab-card-meta"><span class="lab-pill pill-green">Free</span><span class="lab-pill pill-dim">~40 min</span></div>
@@ -1699,6 +1699,32 @@ document.addEventListener('keydown', e => {
   if (e.key === 'Escape') { closeDemoModal(null); closeMobileMenu(); }
 });
 
+// Make free lab cards interactive: open in-browser demo instead of navigating away
+document.querySelectorAll('.lab-card[data-scenario]').forEach((card) => {
+  const scenario = card.dataset.scenario;
+  card.style.cursor = 'pointer';
+  card.addEventListener('click', () => openDemoModal(scenario, card));
+  card.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openDemoModal(scenario, card);
+    }
+  });
+});
+
+async function parseApiJson(response, fallbackMessage = 'Server response is not valid JSON.') {
+  const contentType = response.headers.get('content-type') || '';
+  const text = await response.text();
+  if (!contentType.includes('application/json')) {
+    throw new Error(fallbackMessage);
+  }
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(fallbackMessage);
+  }
+}
+
 // ── Mobile menu ───────────────────────────────────────────────────────────────
 document.getElementById('nav-hamburger').addEventListener('click', () => {
   document.getElementById('mobile-menu').style.display = 'block';
@@ -1722,8 +1748,8 @@ async function loadSeats() {
   try {
     const r = await fetch('/api/early-access/seats');
     if (!r.ok) throw new Error();
-    const d = await r.json();
-    const claimed = d.claimed || d.count || 0;
+    const d = await parseApiJson(r, 'Seat service unavailable right now.');
+    const claimed = d.claimed || d.count || d.taken || 0;
     // If DB is empty, treat as pre-launch state and use social-proof fallback
     if (claimed === 0) throw new Error('empty');
     seatsRemaining = MAX_SEATS - claimed;
@@ -1796,7 +1822,7 @@ async function joinWaitlist() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, name: name || undefined, ref: urlRef || undefined }),
     });
-    const d = await r.json();
+    const d = await parseApiJson(r, 'Temporary server issue. Please retry in a moment.');
     if (!r.ok) throw new Error(d.error || 'Error joining waitlist');
     showSuccess(d.signup);
   } catch(e) {
@@ -1822,7 +1848,7 @@ async function goStripe() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, name: name || undefined }),
     });
-    const d = await r.json();
+    const d = await parseApiJson(r, 'Checkout service unavailable. Please retry.');
     if (!r.ok) {
       if (d.soldOut) { setCtaState('expired'); return; }
       throw new Error(d.error || 'Checkout failed');

--- a/server.js
+++ b/server.js
@@ -14,9 +14,9 @@ import crypto from "crypto";
 import helmet from "helmet";
 import cookieParser from "cookie-parser";
 import { v4 as uuidv4 } from "uuid";
+import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { existsSync } from "fs";
 import { WebSocketServer } from "ws";
 
 import {
@@ -43,6 +43,7 @@ const BASE_PORT  = parseInt(process.env.PORT || "3001", 10);
 const IS_PROD    = process.env.NODE_ENV === "production";
 const JWT_SECRET = process.env.JWT_SECRET || "dev_secret_change_me";
 const ENC_KEY    = (process.env.ENCRYPTION_KEY || "00000000000000000000000000000000").slice(0, 32);
+const EARLY_ACCESS_FILE = path.join(__dirname, "data", "early-access-seats.json");
 
 // ── Clients ──────────────────────────────────────────────────────────
 const prisma    = new PrismaClient();
@@ -761,14 +762,27 @@ app.get("/api/community/bugs", async (req, res) => {
 const MAX_SEATS = 500;
 
 // GET /api/early-access/seats
-app.get("/api/early-access/seats", async (req, res) => {
+app.get("/api/early-access/seats", (req, res) => {
   try {
-    const count = await prisma.earlyAccessSignup.count({ where: { activated: true } });
-    const total = await prisma.earlyAccessSignup.count();
-    res.json({ claimed: count, total, remaining: Math.max(0, MAX_SEATS - count) });
+    if (!fs.existsSync(EARLY_ACCESS_FILE)) {
+      fs.writeFileSync(EARLY_ACCESS_FILE, "[]");
+    }
+
+    let data = [];
+    try {
+      data = JSON.parse(fs.readFileSync(EARLY_ACCESS_FILE, "utf8"));
+    } catch {
+      data = [];
+    }
+
+    const total = MAX_SEATS;
+    const taken = Array.isArray(data) ? data.length : 0;
+    const remaining = Math.max(0, total - taken);
+
+    res.json({ total, taken, remaining });
   } catch (err) {
     console.error("GET /api/early-access/seats error:", err);
-    res.status(500).json({ error: "Failed" });
+    res.status(500).json({ error: "Server error" });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Make the free lab cards on the coming-soon page open an in-browser demo modal and be keyboard accessible instead of navigating away. 
- Hardening client API handling to cope with non-JSON or inconsistent payload shapes and provide clearer fallback messages. 
- Provide a simple file-backed early-access seats endpoint so the app can report seat counts in environments where Prisma/DB or registry access is not available, and record a repo health check for developer diagnostics.

### Description
- Added `data-scenario`, `role`, `tabindex`, and `aria-label` attributes to free lab `.lab-card` elements and wired up click/keyboard handlers to open the demo modal in `coming-soon/index.html`. 
- Implemented `parseApiJson()` helper to safely parse API responses and replaced direct `r.json()` calls in seats, waitlist join, and Stripe checkout flows to surface clearer fallback messages. 
- Adjusted client logic to accept `taken`/`claimed` shapes and update UI fallbacks when the seat service is unavailable. 
- Replaced the Prisma-backed seats reader with a local JSON file-backed implementation in `GET /api/early-access/seats`, including `EARLY_ACCESS_FILE` constant and `fs` import, and changed the returned JSON to `{ total, taken, remaining }`. 
- Added `REPO_CHECK_2026-04-17.md` documenting initial repo installation/test attempts and recommended fixes for dependency and Prisma issues.

### Testing
- Ran `npm ci`, which failed due to a peer dependency conflict between `vite@8.x` and `vite-plugin-pwa@1.2.0`. 
- Ran `npm ci --legacy-peer-deps`, which completed but left the environment inconsistent and caused runtime artifacts (like `vite`) to be unavailable. 
- Ran `npm test`, which failed because `@prisma/client` was not resolving in the current environment. 
- Ran `npx prisma generate`, which failed with a `403 Forbidden` against the npm registry preventing Prisma client generation, so full end-to-end automated tests could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a37f0ca483268efb162acf623378)